### PR TITLE
locally tested - item id clashes, on creation of a deck, now handled.

### DIFF
--- a/src/main/resources/static/js/gameState.js
+++ b/src/main/resources/static/js/gameState.js
@@ -1473,10 +1473,13 @@ const gameState = (function() {
 
         //!isDeck only happens in Canvas interaction, no index
         if(!recipient.isDeck) {
-            push(deckify(donorCards, recipient));
+            let callback = () => {
+                push(deckify(donorCards, recipient));
 
-            relevant.add(donorCards[0].deck);
-            server.pushGameAction("addToDeck", new Array(...relevant));
+                relevant.add(donorCards[0].deck);
+                server.pushGameAction("addToDeck", new Array(...relevant));
+            }
+            server.permission(callback, "", [recipient], "please reserve one");
             return true;
         }
 
@@ -1959,6 +1962,10 @@ const gameState = (function() {
         redraw.triggerRedraw();
     }
 
+    function newItemCount(number) {
+        itemCount = number;
+    }
+
     return {
         getID,
         idToRGB,
@@ -2005,6 +2012,7 @@ const gameState = (function() {
         showHand,
         disconnection,
         clientMovement,
+        newItemCount,
         cleanSlate //for testing - remove once finished testing
     };
 })();

--- a/src/main/resources/static/js/serverConnection.js
+++ b/src/main/resources/static/js/serverConnection.js
@@ -181,6 +181,15 @@ class Server {
 
                         this.server.game.updateItems(data);
                         break;
+                    //TODO - do not take in update if player is not connected to game
+                    //and/or, ensure 'Start Game' sets to 0 first (cleanSlate)
+                    case "NewItemCount":
+                        if(data.senderId == this.server.game.clientUser.id) {
+                            console.log(`returned ${header}!`);
+                            //Do not process;
+                            break;
+                        }
+                        this.server.game.newItemCount(data.itemCount);
                     case "NewPlayer":
                         if(data.senderId == this.server.game.clientUser.id) {
                             console.log(`returned ${header}!`);
@@ -532,7 +541,7 @@ class Server {
     //process outbound permissions
     //serverCheckItems- the most relevant items that end up manipulated at end of func
     //e,g, 'selectView' is the item.deck, often triggered on topCard (not deck)
-    permission(func, funcArgs, serverCheckItems) {
+    permission(func, funcArgs, serverCheckItems, explicit) {
         if(this.connection == undefined || this.connection.readyState != 1) {
             func(...funcArgs);
             return;
@@ -550,6 +559,7 @@ class Server {
 
         let message = {};
         message.messageHeader = "PermissionGameAction";
+        if(explicit) message.explicit = explicit;
         message.senderId = this.game.clientUser.id;     //sender
         message.timeStamp = currentId;
         //Note: weak code, assumes is 'card' or 'deck', and only holds 1 item


### PR DESCRIPTION
before a new item is created, server first reserves the id (=itemCount), then broadcasts new 'itemCount' as baseline for new ids of items to-be-created. the original sender ignores this, and creates the object.