### PR TITLE
Full Touch update

### DIFF
--- a/src/main/java/org/example/handlers/RequestProcessor.java
+++ b/src/main/java/org/example/handlers/RequestProcessor.java
@@ -474,9 +474,9 @@ public class RequestProcessor {
                 Card serverCopy = (Card) quickRef.get((long) card.id);
                 if(serverCopy == null || serverCopy.timeStamp != card.timeStamp) {
                     message.bool = false;
-//                    System.out.println("Card timestamp mismatch!");
-//                    System.out.printf("ClntCopy: %s%n", card.timeStamp);
-//                    System.out.printf("SrvrCopy: %s%n", serverCopy.timeStamp);
+                    System.out.println("Card timestamp mismatch!");
+                    System.out.printf("ClntCopy: %s%n", card.timeStamp);
+                    System.out.printf("SrvrCopy: %s%n", serverCopy.timeStamp);
                 } else {
 //                    System.out.printf("ClntCopy: %s%n", card.timeStamp);
 //                    System.out.printf("SrvrCopy: %s%n", serverCopy.timeStamp);
@@ -492,9 +492,9 @@ public class RequestProcessor {
                 Deck serverCopy = (Deck) quickRef.get((long) deck.id);
                 if(serverCopy == null || serverCopy.timeStamp != deck.timeStamp) {
                     message.bool = false;
-//                    System.out.println("Deck timestamp mismatch!");
-//                    System.out.printf("ClntCopy: %s%n", deck.timeStamp);
-//                    System.out.printf("SrvrCopy: %s%n", serverCopy.timeStamp);
+                    System.out.println("Deck timestamp mismatch!");
+                    System.out.printf("ClntCopy: %s%n", deck.timeStamp);
+                    System.out.printf("SrvrCopy: %s%n", serverCopy.timeStamp);
                 } else {
 //                    System.out.printf("Deck: %s%n", deck.timeStamp);
                     decks.add(serverCopy);

--- a/src/main/resources/static/js/boardInterface.js
+++ b/src/main/resources/static/js/boardInterface.js
@@ -98,12 +98,30 @@ class PreviewBox {
     }
 
     //TODO- turn childImgContainer into childContainerDiv - test for visual inaccuracies
-    update() {
+    //Note - 'element' is event root, must not be removed from DOM for touchscreen events to work smoothly
+    update(element) {
         //purge children
         const parent = this.cardHolder;
-        while(parent.firstChild) {
-            delete parent.firstChild.card.ref;
-            parent.firstChild.remove();
+//        while(parent.firstChild) {
+//            delete parent.firstChild.card.ref;
+//            parent.firstChild.remove();
+//        }
+
+        //Below WORKS
+        let i = 0;
+        while(parent.children.item(i)) {
+            const child = parent.children.item(i);
+            delete child.card.ref
+            //if match specific card, increment index; else, delete
+            if(child.card==element) {
+                i++;
+                console.log("that's me!");
+                //make it invisible
+                //NOTE: future updates does 'remove' this element
+                child.style.display='none';
+            } else {
+                parent.removeChild(child);
+            }
         }
 
         if(!this.cardModel || !this.cardModel.images) return;
@@ -219,14 +237,14 @@ class ViewDeck extends PreviewBox {
     //TODO- see if leaving it unchecked for now will break the code launch
 
     //override update()-
-    update() {
+    update(element) {
         if(this.cardModel == null || this.cardModel == undefined) {
             this.cardHolder.setAttribute("empty-hand-text", this.noDeckSelectedText);
             this.minimizeBody();
         } else {
             this.cardHolder.setAttribute("empty-hand-text", this.hideText);
         }
-        super.update();
+        super.update(element);
     }
 
     hideBody() {

--- a/src/main/resources/static/js/boardInterface.js
+++ b/src/main/resources/static/js/boardInterface.js
@@ -111,11 +111,10 @@ class PreviewBox {
         let i = 0;
         while(parent.children.item(i)) {
             const child = parent.children.item(i);
-            delete child.card.ref
+            delete child.card.ref;
             //if match specific card, increment index; else, delete
             if(child.card==element) {
                 i++;
-                console.log("that's me!");
                 //make it invisible
                 //NOTE: future updates does 'remove' this element
                 child.style.display='none';

--- a/src/main/resources/static/js/gameState.js
+++ b/src/main/resources/static/js/gameState.js
@@ -1533,8 +1533,8 @@ const gameState = (function() {
 
         //ref = visual interface (preview)
         if(deck.ref) {
-            userInterface.playerBar.playerUpdate();
-            deck.ref.update();
+            userInterface.playerBar.playerUpdate();     //Update card count on GUI
+            deck.ref.update(card);                      //for touch purposes, element match => do not remove from DOM
         }
 
         //TODO- keep a "JSON.stringify, JSON.parse" fallback state for 'otherCard'

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -511,23 +511,27 @@ window.addEventListener("load", (event) => {
         itemFocus = null;
         dragging = false;
 
-        //simulate rClick
-        const touch = event.changedTouches[0];
-        rightClick = true;
-        event.target.dispatchEvent(new MouseEvent("mouseup", {
-                screenX: touch.screenX,
-                screenY: touch.screenY,
-                buttons: 2,
-                clientX: touch.clientX,
-                clientY: touch.clientY,
-                ctrlKey: event.ctrlKey,
-                shiftKey: event.shiftKey,
-                altKey: event.altKey,
-                metaKey: event.metaKey,
-                view: window,
-                bubbles: true,
-                sourceCapabilities: new InputDeviceCapabilities({fireTouchEvents: true})
-        }));
+        //some millisecond gap not present in mouseRClick is present here,
+        //using setTimeout as buffer
+        setTimeout(() => {
+            //simulate rClick
+            const touch = event.changedTouches[0];
+            rightClick = true;
+            event.target.dispatchEvent(new MouseEvent("mouseup", {
+                    screenX: touch.screenX,
+                    screenY: touch.screenY,
+                    buttons: 2,
+                    clientX: touch.clientX,
+                    clientY: touch.clientY,
+                    ctrlKey: event.ctrlKey,
+                    shiftKey: event.shiftKey,
+                    altKey: event.altKey,
+                    metaKey: event.metaKey,
+                    view: window,
+                    bubbles: true,
+                    sourceCapabilities: new InputDeviceCapabilities({fireTouchEvents: true})
+            }));
+        }, 25); //NOTE: 25ms is arbitrary
     };
 
     window.addEventListener("mousedown", function(event) {
@@ -1143,7 +1147,6 @@ window.addEventListener("load", (event) => {
                 longPress = setTimeout(longPressRClick, longPressInterval, evt);
             }
 
-
             break;
         case "touchmove":
             type = "mousemove";
@@ -1204,7 +1207,6 @@ window.addEventListener("load", (event) => {
     window.addEventListener("touchend", onTouch, {passive: false});
     window.addEventListener("touchcancel", onTouch, {passive: false});
     window.addEventListener("touchmove", onTouch, {passive: false});
-
 
     //For some reason, this needs to be called twice in order to properly capture, as far as tested, "mousedown"
     pulseRedraw();

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -1069,11 +1069,9 @@ window.addEventListener("load", (event) => {
 //        console.log("hey!");
 //        console.log(evt.type);
 //        evt.preventDefault();
-        if (
-            evt.touches.length > 1 ||
-            (evt.type === "touchend" && evt.touches.length > 0)
-        )
-        return;
+        if ( evt.touches.length > 1 || (evt.type === "touchend" && evt.touches.length > 0)) {
+            return;
+        }
 
         let type = null;
         let touch = null;

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -504,33 +504,39 @@ window.addEventListener("load", (event) => {
         }
 //        console.log("boop! longpress!");
 
-        //reset all 'select'
-        purgeSelected();
-        gameState.deselect(itemFocus);
-        startPoint = null;
+        const touch = event.changedTouches[0];
+        rightClick = true;
+        const rightClickEvent = new MouseEvent("mouseup", {
+            screenX: touch.screenX,
+            screenY: touch.screenY,
+            buttons: 2,
+            clientX: touch.clientX,
+            clientY: touch.clientY,
+            ctrlKey: event.ctrlKey,
+            shiftKey: event.shiftKey,
+            altKey: event.altKey,
+            metaKey: event.metaKey,
+            view: window,
+            bubbles: true,
+            sourceCapabilities: new InputDeviceCapabilities({fireTouchEvents: true})
+        });
+
+        if(itemFocus && itemFocus.deck && itemFocus.deck.selected == user.id) {
+//            console.log("yippee!");
+        } else {
+//            console.log("yippeen't :(");
+
+            //reset all 'select'
+            purgeSelected();
+        }
+
+        //prevents current itemFocus from being 'cycleImage()'-d
         itemFocus = null;
 
-        //some millisecond gap not present in mouseRClick is present here,
-        //using setTimeout as buffer
-        setTimeout(() => {
-            //simulate rClick
-            const touch = event.changedTouches[0];
-            rightClick = true;
-            event.target.dispatchEvent(new MouseEvent("mouseup", {
-                    screenX: touch.screenX,
-                    screenY: touch.screenY,
-                    buttons: 2,
-                    clientX: touch.clientX,
-                    clientY: touch.clientY,
-                    ctrlKey: event.ctrlKey,
-                    shiftKey: event.shiftKey,
-                    altKey: event.altKey,
-                    metaKey: event.metaKey,
-                    view: window,
-                    bubbles: true,
-                    sourceCapabilities: new InputDeviceCapabilities({fireTouchEvents: true})
-            }));
-        }, 500); //NOTE: 25ms is arbitrary
+        event.target.dispatchEvent(rightClickEvent);
+
+        //completes 'itemFocus = null', deselecting once finished
+        gameState.deselect(itemFocus);
     };
 
     window.addEventListener("mousedown", function(event) {

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -1123,13 +1123,44 @@ window.addEventListener("load", (event) => {
 
     preventRightClickDefault();
 
+    let startPinch = false;
+    //...are we making our own touchEvents?
+    let touchPoints = [];
+    let initialLength;
+
+    const pinchzoom = function(event) {
+        if(event.touches.length != 2) {
+            startPinch = false;
+            return;
+        }
+
+        //note: touchPoints contains ORIGINAL positions, hence compare length
+        let a = event.touches[0];
+        let b = event.touches[1];
+
+        const newLength = Math.abs(a.clientX - b.clientX) +
+                          Math.abs(a.clientY - b.clientY);
+        let result;
+        const rate = 0.5;
+        if(initialLength < newLength) {
+            result = rate; //zooming in
+        } else {
+            result = -rate; //zooming out
+        }
+
+        initialLength = newLength;
+
+        zoom(result);
+        return;
+    }
+
     //Touch-event -> Mouse-event / Wheel event
     //https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent
     function onTouch(evt) {
-//        console.log("hey!");
-//        console.log(evt.type);
-//        evt.preventDefault();
-        if ( evt.touches.length > 1 || (evt.type === "touchend" && evt.touches.length > 0)) {
+
+        if (
+//        evt.touches.length > 1 ||
+        (evt.type === "touchend" && evt.touches.length > 0)) {
             return;
         }
 
@@ -1153,15 +1184,31 @@ window.addEventListener("load", (event) => {
                 longPress = setTimeout(longPressRClick, longPressInterval, evt);
             }
 
+            if(evt.touches.length == 2) {
+                startPinch = true;
+                touchPoints[0] = {
+                    x: evt.touches[0].clientX,
+                    y: evt.touches[0].clientY
+                }
+                touchPoints[1] = {
+                    x: evt.touches[1].clientX,
+                    y: evt.touches[1].clientY
+                }
+                initialLength = Math.abs(touchPoints[0].x - touchPoints[1].x) +
+                                Math.abs(touchPoints[0].y - touchPoints[1].y);
+            } else {
+                startPinch = false;
+            }
+
             break;
         case "touchmove":
             type = "mousemove";
             touch = evt.changedTouches[0];
-//            if(evt.target instanceof HTMLImageElement) {
-//                console.log("moving image");
-//            } else {
-//                console.log("moving");
-//            }
+
+            if(startPinch) {
+                pinchzoom(evt);
+            }
+
             break;
         case "touchend":
             type = "mouseup";
@@ -1170,15 +1217,27 @@ window.addEventListener("load", (event) => {
                 evt.preventDefault();
 //                target = evt.currentTarget;
             }
-//            console.log("touchend");
             break;
         }
+
+        //'center' of a pinch to prevent dragging tug-of-war between two points (very stuttery)
+        let screenX;
+        let screenY;
+        let clientX;
+        let clientY;
+        if(evt.touches.length == 2) {
+            screenX = (evt.touches[0].screenX + evt.touches[1].screenX)/2;
+            screenY = (evt.touches[0].screenY + evt.touches[1].screenY)/2;
+            clientX = (evt.touches[0].clientX + evt.touches[1].clientX)/2;
+            clientY = (evt.touches[0].clientY + evt.touches[1].clientY)/2;
+        }
+
         let newEvt = new MouseEvent(type, {
-            screenX: touch.screenX,
-            screenY: touch.screenY,
+            screenX: screenX || touch.screenX,
+            screenY: screenY || touch.screenY,
             buttons: buttons,               //TODO - mousedown, value = 2 for rClick pings/deckView
-            clientX: touch.clientX,
-            clientY: touch.clientY,
+            clientX: clientX || touch.clientX,
+            clientY: clientY || touch.clientY,
             ctrlKey: evt.ctrlKey,
             shiftKey: evt.shiftKey,
             altKey: evt.altKey,
@@ -1186,17 +1245,16 @@ window.addEventListener("load", (event) => {
             view: window,
             bubbles: true,
             sourceCapabilities: new InputDeviceCapabilities({fireTouchEvents: true})
-
         });
 
         //this is a CATCHUP - mousemove is crucial for initializing some references, and affects subsequent mousedown
         if(type == "mousedown") {
             evt.target.dispatchEvent(new MouseEvent("mousemove", {
-                    screenX: touch.screenX,
-                    screenY: touch.screenY,
+                    screenX: screenX || touch.screenX,
+                    screenY: screenY || touch.screenY,
                     buttons: buttons,               //TODO - mousedown, value = 2 for rClick pings/deckView
-                    clientX: touch.clientX,
-                    clientY: touch.clientY,
+                    clientX: clientX || touch.clientX,
+                    clientY: clientY || touch.clientY,
                     ctrlKey: evt.ctrlKey,
                     shiftKey: evt.shiftKey,
                     altKey: evt.altKey,

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -120,7 +120,8 @@ window.addEventListener("load", (event) => {
         y: board.height
     };
 
-    let startPoint;
+    let startPoint;         //translated to canvas dimensions
+    let startPointReal;     //taken from actual mouse positions
     let dragging = false;
 
     //purpose: manage 'redraw' loop
@@ -420,8 +421,17 @@ window.addEventListener("load", (event) => {
             handleEdgePanlooping = false;
         }
     }
+    const threshold = 15; //pixels, arbitrary
     const handleDrag = function(event) {
         if(!startPoint) {
+            return;
+        }
+        //TODO attempt - if via touch, prevent drag if net change in x+y not reached
+        if(
+        !dragging &&
+        !event.isTrusted &&     //criteria only enables feature for 'crafted' events (Touch)
+        Math.abs(mouse.x - startPointReal.x) + Math.abs(mouse.y - startPointReal.y) < threshold) {
+            console.log("Drag rejected: deviation too small");
             return;
         }
 
@@ -480,6 +490,7 @@ window.addEventListener("load", (event) => {
         //handle tooltip hover- if canvas, finds object
         handleImageTooltip();
 
+        //TODO - determine 'sensitivity' for touch
         //check for click-hold-drag
         handleDrag(event);
 
@@ -503,12 +514,14 @@ window.addEventListener("load", (event) => {
         } else if (!(hoverElement instanceof HTMLCanvasElement) && !isPreviewCard) {
             //Invalid drag/select point - not Canvas nor PreviewCard
             startPoint = null;
+            startPointReal = null;
             gameState.startPoint(null);
             gameState.offset(null);
         } else {
             //Valid drag/select point
             document.body.classList.add("grabbing");
             startPoint = contextVis.transformPoint(mouse.x, mouse.y);
+            startPointReal = { x: mouse.x, y: mouse.y };
             gameState.startPoint(startPoint);
             gameState.offset(
                 {x: event.offsetX, y: event.offsetY}

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -527,7 +527,6 @@ window.addEventListener("load", (event) => {
         } else {
             userInterface.userInterface.chatBox.newEntry("longpress yippeen't :(",undefined,"");
             console.log("longpress yippeen't :(");
-            gameState.
             //reset all 'select'
             purgeSelected();
         }

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -198,6 +198,8 @@ window.addEventListener("load", (event) => {
         //if this is 'back' image, do not display
         if(!item || (item.index == 0 && !isPreview)) {
             inspectImage.style.visibility = `hidden`;
+            inspectImage.style.top = `${0}px`;
+            inspectImage.style.left = `${0}px`;
             return;
         }
         //TODO to become item.getImage() under 'genericFactory'

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -421,12 +421,13 @@ window.addEventListener("load", (event) => {
             handleEdgePanlooping = false;
         }
     }
-    const threshold = 15; //pixels, arbitrary
+    const threshold = 10; //pixels, arbitrary
     const handleDrag = function(event) {
         if(!startPoint) {
             return;
         }
-        //TODO attempt - if via touch, prevent drag if net change in x+y not reached
+
+        //Touch lenience: 'tap' made accessible by introducing a movement threshold to validate 'moving' attempts
         if(
         !dragging &&
         !event.isTrusted &&     //criteria only enables feature for 'crafted' events (Touch)
@@ -490,7 +491,6 @@ window.addEventListener("load", (event) => {
         //handle tooltip hover- if canvas, finds object
         handleImageTooltip();
 
-        //TODO - determine 'sensitivity' for touch
         //check for click-hold-drag
         handleDrag(event);
 

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -522,10 +522,12 @@ window.addEventListener("load", (event) => {
         });
 
         if(itemFocus && itemFocus.deck && itemFocus.deck.selected == user.id) {
-//            console.log("yippee!");
+            userInterface.userInterface.chatBox.newEntry("longpress yippee!",undefined,"");
+            console.log("longpress yippee!");
         } else {
-//            console.log("yippeen't :(");
-
+            userInterface.userInterface.chatBox.newEntry("longpress yippeen't :(",undefined,"");
+            console.log("longpress yippeen't :(");
+            gameState.
             //reset all 'select'
             purgeSelected();
         }

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -522,11 +522,9 @@ window.addEventListener("load", (event) => {
         });
 
         if(itemFocus && itemFocus.deck && itemFocus.deck.selected == user.id) {
-            userInterface.userInterface.chatBox.newEntry("longpress yippee!",undefined,"");
-            console.log("longpress yippee!");
+//            console.log("longpress yippee!");
         } else {
-            userInterface.userInterface.chatBox.newEntry("longpress yippeen't :(",undefined,"");
-            console.log("longpress yippeen't :(");
+//            console.log("longpress yippeen't :(");
             //reset all 'select'
             purgeSelected();
         }

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -432,7 +432,6 @@ window.addEventListener("load", (event) => {
         !dragging &&
         !event.isTrusted &&     //criteria only enables feature for 'crafted' events (Touch)
         Math.abs(mouse.x - startPointReal.x) + Math.abs(mouse.y - startPointReal.y) < threshold) {
-            console.log("Drag rejected: deviation too small");
             return;
         }
 
@@ -495,6 +494,41 @@ window.addEventListener("load", (event) => {
         handleDrag(event);
 
     },false);
+
+    let longPress = null;
+    const longPressInterval = 1000; //milliseconds
+    const longPressRClick = function(event) {
+        if(dragging || startPoint == null) {
+//            console.log("boopn't! longpressn't!");
+            return;
+        }
+//        console.log("boop! longpress!");
+
+        //reset all 'select'
+        purgeSelected();
+        gameState.deselect(itemFocus);
+        startPoint = null;
+        itemFocus = null;
+        dragging = false;
+
+        //simulate rClick
+        const touch = event.changedTouches[0];
+        rightClick = true;
+        event.target.dispatchEvent(new MouseEvent("mouseup", {
+                screenX: touch.screenX,
+                screenY: touch.screenY,
+                buttons: 2,
+                clientX: touch.clientX,
+                clientY: touch.clientY,
+                ctrlKey: event.ctrlKey,
+                shiftKey: event.shiftKey,
+                altKey: event.altKey,
+                metaKey: event.metaKey,
+                view: window,
+                bubbles: true,
+                sourceCapabilities: new InputDeviceCapabilities({fireTouchEvents: true})
+        }));
+    };
 
     window.addEventListener("mousedown", function(event) {
 //        console.log("mousedown received");
@@ -1100,8 +1134,16 @@ window.addEventListener("load", (event) => {
             buttons = 1; //TODO - =2 is rClick needed for deck view
             if(evt.target instanceof HTMLCanvasElement || evt.target instanceof HTMLImageElement) {
                 evt.preventDefault();
-//                target = evt.currentTarget;
+
+                //handles emulating rClick for touch
+                if(longPress) {
+                    clearTimeout(longPress);
+                    longPress = null;
+                }
+                longPress = setTimeout(longPressRClick, longPressInterval, evt);
             }
+
+
             break;
         case "touchmove":
             type = "mousemove";

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -464,6 +464,7 @@ window.addEventListener("load", (event) => {
         mouse.x = event.pageX;
         mouse.y = event.pageY;
 
+        //Track user movement for online
         gameState.clientMovement(contextVis.transformPoint(mouse.x, mouse.y));
 
         hoverElement = document.elementFromPoint(mouse.x, mouse.y);
@@ -1117,13 +1118,14 @@ window.addEventListener("load", (event) => {
             altKey: evt.altKey,
             metaKey: evt.metaKey,
             view: window,
+            bubbles: true,
             sourceCapabilities: new InputDeviceCapabilities({fireTouchEvents: true})
 
         });
 
         //this is a CATCHUP - mousemove is crucial for initializing some references, and affects subsequent mousedown
         if(type == "mousedown") {
-            evt.currentTarget.dispatchEvent(new MouseEvent("mousemove", {
+            evt.target.dispatchEvent(new MouseEvent("mousemove", {
                     screenX: touch.screenX,
                     screenY: touch.screenY,
                     buttons: buttons,               //TODO - mousedown, value = 2 for rClick pings/deckView
@@ -1134,11 +1136,11 @@ window.addEventListener("load", (event) => {
                     altKey: evt.altKey,
                     metaKey: evt.metaKey,
                     view: window,
+                    bubbles: true,
                     sourceCapabilities: new InputDeviceCapabilities({fireTouchEvents: true})
-
             }));
         }
-        evt.currentTarget.dispatchEvent(newEvt);
+        evt.target.dispatchEvent(newEvt);
     }
 
     window.addEventListener("touchstart", onTouch, {passive: false});

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -496,7 +496,7 @@ window.addEventListener("load", (event) => {
     },false);
 
     let longPress = null;
-    const longPressInterval = 1000; //milliseconds
+    const longPressInterval = 500; //milliseconds
     const longPressRClick = function(event) {
         if(dragging || startPoint == null) {
 //            console.log("boopn't! longpressn't!");
@@ -509,7 +509,6 @@ window.addEventListener("load", (event) => {
         gameState.deselect(itemFocus);
         startPoint = null;
         itemFocus = null;
-        dragging = false;
 
         //some millisecond gap not present in mouseRClick is present here,
         //using setTimeout as buffer
@@ -531,7 +530,7 @@ window.addEventListener("load", (event) => {
                     bubbles: true,
                     sourceCapabilities: new InputDeviceCapabilities({fireTouchEvents: true})
             }));
-        }, 25); //NOTE: 25ms is arbitrary
+        }, 500); //NOTE: 25ms is arbitrary
     };
 
     window.addEventListener("mousedown", function(event) {

--- a/src/main/resources/static/js/serverConnection.js
+++ b/src/main/resources/static/js/serverConnection.js
@@ -588,6 +588,8 @@ class Server {
         let currentId = Date.now();
         this.#pendingPermissions[currentId] = [func, funcArgs];
 
+//        console.log("permissioning!");
+
         //assuming funcArgs is one item... card/deckm
 
         let message = {};
@@ -624,6 +626,9 @@ class Server {
             callBack[0](...callBack[1]);
 
             delete this.#pendingPermissions[data.timeStamp];
+//            console.log("yipee!");
+        } else {
+//            console.log("cry");
         }
     }
 

--- a/src/main/resources/static/js/sidebar.js
+++ b/src/main/resources/static/js/sidebar.js
@@ -88,7 +88,9 @@ export class MenuOption {
         if(!func) { //defaults to creating a popup contextMenu
             func = this.createContextMenu;
         }
-        this.container.addEventListener(`pointerdown`, func, false);
+        this.container.addEventListener(`click`, (event) => {
+            func();
+        }, {passive: false});
         return this;
     }
 


### PR DESCRIPTION
This branch introduces touch capability.

Tablet and/or mobile users can now move cards, view decks, interact with the hand and deck previews, and zoom in and out.

Missing features not likely to be implemented for touch:

- Deck sidescrolling, or deep deck browsing
- Lock playmats
- Rotate game pieces directly